### PR TITLE
Filtering results

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -93,6 +93,12 @@ And viewing the service in your browser: <a href="http://localhost:5678/search?t
 
 The `/search` method supports multiple `types` as well as an optional `limit`. For example: `http://localhost:5678/search?types[]=event&types[]=venue&types[]=performer&limit=3&term=yank`.
 
+### Filterable data
+
+If you want your data to be filterable by other arbitrary values, you can add them to a key called filterable as a hash in the format of indexName:value. This is useful when your items fall in to a number of discrete buckets, like zip code or city and you want to be able to narrow your results.
+
+You can specify filters in your URL to the server in the form of `filters[type][indexName]=value`, eg. `http://localhost:5678/search?types[]=event&filters[event][state]=CA&term=yank` to find events in California.
+
 Contributing to soulmate
 ------------------------
  

--- a/lib/soulmate/loader.rb
+++ b/lib/soulmate/loader.rb
@@ -37,7 +37,7 @@ module Soulmate
           
           filters.each_pair do |index, value|
             value = normalize(value).gsub(/ /, '')
-            Soulmate.redis.sadd("#{base}:#{p}:filters:#{index}:#{value}", id)
+            Soulmate.redis.zadd("#{base}:#{p}filters:#{index}:#{value}", 0, id)
           end
           items_loaded += 1
         end

--- a/lib/soulmate/loader.rb
+++ b/lib/soulmate/loader.rb
@@ -24,6 +24,7 @@ module Soulmate
         id    = item["id"]
         term  = item["term"]
         score = item["score"]
+        filters = item["filterable"] || {}
 
         if id and term
           # store the raw data in a separate key to reduce memory usage
@@ -32,6 +33,11 @@ module Soulmate
           prefixes_for_phrase(term).each do |p|
             Soulmate.redis.sadd(base, p) # remember this prefix in a master set
             Soulmate.redis.zadd("#{base}:#{p}", score, id) # store the id of this term in the index
+          end
+          
+          filters.each_pair do |index, value|
+            value = normalize(value).gsub(/ /, '')
+            Soulmate.redis.sadd("#{base}:#{p}:filters:#{index}:#{value}", id)
           end
           items_loaded += 1
         end

--- a/lib/soulmate/matcher.rb
+++ b/lib/soulmate/matcher.rb
@@ -14,12 +14,12 @@ module Soulmate
 
       if !Soulmate.redis.exists(cachekey)
         interkeys = words.map { |w| "#{base}:#{w}" }
-        
+
         interkeys += options[:filters].to_a.map do |filter|
           value = filter.last.downcase.strip.gsub(/ /, '')
           "#{base}:filters:#{filter.first}:#{value}"
         end
-        p interkeys
+
         Soulmate.redis.zinterstore(cachekey, interkeys)
         Soulmate.redis.expire(cachekey, 10 * 60) # expire after 10 minutes
       end

--- a/lib/soulmate/matcher.rb
+++ b/lib/soulmate/matcher.rb
@@ -8,11 +8,18 @@ module Soulmate
       end.sort
 
       options[:limit] ||= 5
+      options[:filters] ||= {}
 
-      cachekey = "#{cachebase}:" + words.join('|')
+      cachekey = "#{cachebase}:" + words.join('|') + ":" + options[:filters].to_s
 
       if !Soulmate.redis.exists(cachekey)
         interkeys = words.map { |w| "#{base}:#{w}" }
+        
+        interkeys += options[:filters].to_a.map do |filter|
+          value = filter.last.downcase.strip.gsub(/ /, '')
+          "#{base}:filters:#{filter.first}:#{value}"
+        end
+        p interkeys
         Soulmate.redis.zinterstore(cachekey, interkeys)
         Soulmate.redis.expire(cachekey, 10 * 60) # expire after 10 minutes
       end

--- a/lib/soulmate/server.rb
+++ b/lib/soulmate/server.rb
@@ -24,7 +24,8 @@ module Soulmate
       results = {}
       types.each do |type|
         matcher = Matcher.new(type)
-        results[type] = matcher.matches_for_term(term, :limit => limit)
+        filters = params[:filters] && params[:filters][type] ? params[:filters][type] : {}
+        results[type] = matcher.matches_for_term(term, :limit => limit, :filters => filters)
       end
       
       JSON.pretty_generate({

--- a/test/samples/venues.json
+++ b/test/samples/venues.json
@@ -1,5 +1,5 @@
-{"id":1,"term":"Dodger Stadium","score":85,"data":{"url":"\/dodger-stadium-tickets\/","subtitle":"Los Angeles, CA"}}
-{"id":28,"term":"Angel Stadium","score":85,"data":{"url":"\/angel-stadium-tickets\/","subtitle":"Anaheim, CA"}}
-{"id":30,"term":"Chase Field ","score":85,"data":{"url":"\/chase-field-tickets\/","subtitle":"Phoenix, AZ"}}
-{"id":29,"term":"Sun Life Stadium","score":84,"data":{"url":"\/sun-life-stadium-tickets\/","subtitle":"Miami, FL"}}
-{"id":2,"term":"Turner Field","score":83,"data":{"url":"\/turner-field-tickets\/","subtitle":"Atlanta, GA"}}
+{"id":1,"term":"Dodger Stadium","score":85,"filterable":{"coast":"west"},"data":{"url":"\/dodger-stadium-tickets\/","subtitle":"Los Angeles, CA"}}
+{"id":28,"term":"Angel Stadium","score":85,"filterable":{"coast":"west"},"data":{"url":"\/angel-stadium-tickets\/","subtitle":"Anaheim, CA"}}
+{"id":30,"term":"Chase Field ","score":85,"filterable":{"coast":"west"},"data":{"url":"\/chase-field-tickets\/","subtitle":"Phoenix, AZ"}}
+{"id":29,"term":"Sun Life Stadium","score":84,"filterable":{"coast":"east"},"data":{"url":"\/sun-life-stadium-tickets\/","subtitle":"Miami, FL"}}
+{"id":2,"term":"Turner Field","score":83,"filterable":{"coast":"east"},"data":{"url":"\/turner-field-tickets\/","subtitle":"Atlanta, GA"}}

--- a/test/test_soulmate.rb
+++ b/test/test_soulmate.rb
@@ -18,4 +18,23 @@ class TestSoulmate < Test::Unit::TestCase
     assert_equal 3, results.size
     assert_equal 'Angel Stadium', results[0]['term']
   end
+
+  def test_integration_can_load_values_and_query_with_filters
+    items = []
+    venues = File.open(File.expand_path(File.dirname(__FILE__)) + '/samples/venues.json', "r")
+    venues.each_line do |venue|
+      items << JSON.parse(venue)
+    end
+    
+    items_loaded = Soulmate::Loader.new('venues').load(items)
+    
+    assert_equal 5, items_loaded
+    
+    matcher = Soulmate::Matcher.new('venues')
+    results = matcher.matches_for_term('stad', :filters => { :coast => 'west' },
+                                               :limit => 5)
+    
+    assert_equal 2, results.size
+    assert_equal 'Angel Stadium', results[0]['term']
+  end
 end


### PR DESCRIPTION
Adds the ability to filter your data down. This is useful when your items fall in to a number of discrete buckets, like zip code or city and you want to be able to narrow your results.