### PR TITLE
Extended bin/loader to be more memory efficient for large datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pkg
 test/db/*.rdb
 
 Gemfile.lock
+
+.rvmrc

--- a/bin/soulmate
+++ b/bin/soulmate
@@ -9,6 +9,7 @@ rescue LoadError
 end
 require 'soulmate'
 require 'optparse'
+require 'tempfile'
 
 parser = OptionParser.new do |opts|
   opts.banner = "Usage: soulmate [options] COMMAND"
@@ -31,30 +32,84 @@ parser = OptionParser.new do |opts|
     exit
   end
 
+  opts.on("-b", "--batch-size", "Number of lines to read at a time") do |size|
+    BATCH_SIZE = size
+  end
+
   opts.separator ""
   opts.separator "Commands:"
-  opts.separator "  load   TYPE FILE BATCH  Replaces collection specified by TYPE with items read from FILE in the JSON lines format, BATCH lines at a time (default of 10000)."
-  opts.separator "  add    TYPE             Adds items to collection specified by TYPE read from stdin in the JSON lines format."
-  opts.separator "  remove TYPE             Removes items from collection specified by TYPE read from stdin in the JSON lines format. Items only require an 'id', all other fields are ignored."
-  opts.separator "  query  TYPE QUERY       Queries for items from collection specified by TYPE."
+  opts.separator "  load   TYPE FILE  Replaces collection specified by TYPE with items read from FILE in the JSON lines format."
+  opts.separator "  add    TYPE       Adds items to collection specified by TYPE read from stdin in the JSON lines format."
+  opts.separator "  remove TYPE       Removes items from collection specified by TYPE read from stdin in the JSON lines format. Items only require an 'id', all other fields are ignored."
+  opts.separator "  query  TYPE QUERY Queries for items from collection specified by TYPE."
+end
+
+def generate(type, file)
+  include Soulmate::Helpers
+
+  begin
+    temp = Tempfile.new("soulmate")
+
+    if File.exists?(file)
+      start_time = Time.now.to_i
+      base = "soulmate-index:#{type}"
+      database = "soulmate-data:#{type}"
+      # hset = "*4\r\n$4\r\nHSET\r\n$#{database.length}\r\n#{database}\r\n$"
+      # del = "*2\r\n$3\r\nDEL\r\n$"
+      begin
+        f = File.open(file)
+        # cleanup
+        phrases = Soulmate.redis.smembers(base)
+        phrases.each do |phrase|
+          temp << gen_redis_proto("DEL", phrase)
+          # temp << del + phrase.length.to_s + "\r\n" + phrase + "\r\n"
+        end
+        temp << gen_redis_proto("DEL", base)
+        # temp << del + base.length.to_s + "\r\n" + base + "\r\n"
+        while !f.eof?
+          line = f.gets.chomp
+          line =~ /"id":(\d+)/
+          id = $1
+          line =~ /"score":(\d+)/
+          score = $1
+          json = MultiJson.decode(line)
+          temp << gen_redis_proto("HSET", database, id, line)
+          # temp << hset + $1.length.to_s + "\r\n" + $1 + "\r\n$" + line.length.to_s + "\r\n" + line + "\r\n"
+          phrase = json.key?("aliases") ? json["term"] + " " + json["aliases"] : json["term"]
+          prefixes_for_phrase(phrase).each do |p|
+            temp << gen_redis_proto("SADD", base, p)
+            temp << gen_redis_proto("ZADD", base + ":" + p, score, id)
+          end
+        end
+      ensure
+        f.close
+      end
+      puts "Converted in #{Time.now.to_i - start_time} second(s)"
+      puts "Importing into redis ..."
+      `time redis-cli --pipe < #{temp.path}`
+    else
+      puts "Couldn't open file: #{file}"
+    end
+  ensure
+    temp.close
+  end
 end
 
 def load(type, file)
   if File.exists?(file)
-    batch_size = ARGV[3].to_i.zero? ? 10000 : ARGV[3].to_i
     start_time = Time.now.to_i
 
     puts "Purging existing items of type #{type} ..."
     loader = Soulmate::Loader.new(type)
     loader.cleanup
 
-    puts "Loading items of type #{type} in batches of #{batch_size} ..."
+    puts "Loading items of type #{type} in batches of #{BATCH_SIZE} ..."
     count = 0
     begin
       f = File.open(file)
       while !f.eof?
         lines = []
-        batch_size.times do
+        BATCH_SIZE.times do
           break if f.eof?
           lines << MultiJson.decode(f.gets)
           count += 1
@@ -101,9 +156,21 @@ def query(type, query)
   puts "> Found #{results.size} matches"
 end
 
+def gen_redis_proto(*cmd)
+  proto = "*"+cmd.length.to_s+"\r\n"
+  cmd.each{|arg|
+    proto << "$"+arg.bytesize.to_s+"\r\n"
+    proto << arg+"\r\n"
+  }
+  proto
+end
+
 parser.parse!
+BATCH_SIZE ||= 1000
 
 case ARGV[0]
+when 'generate'
+  generate ARGV[1], ARGV[2]
 when 'load'
   load ARGV[1], ARGV[2]
 when 'add'

--- a/bin/soulmate
+++ b/bin/soulmate
@@ -33,17 +33,42 @@ parser = OptionParser.new do |opts|
 
   opts.separator ""
   opts.separator "Commands:"
-  opts.separator "  load   TYPE        Replaces collection specified by TYPE with items read from stdin in the JSON lines format."
-  opts.separator "  add    TYPE        Adds items to collection specified by TYPE read from stdin in the JSON lines format."
-  opts.separator "  remove TYPE        Removes items from collection specified by TYPE read from stdin in the JSON lines format. Items only require an 'id', all other fields are ignored."
-  opts.separator "  query  TYPE QUERY  Queries for items from collection specified by TYPE."
+  opts.separator "  load   TYPE FILE BATCH  Replaces collection specified by TYPE with items read from FILE in the JSON lines format, BATCH lines at a time (default of 10000)."
+  opts.separator "  add    TYPE             Adds items to collection specified by TYPE read from stdin in the JSON lines format."
+  opts.separator "  remove TYPE             Removes items from collection specified by TYPE read from stdin in the JSON lines format. Items only require an 'id', all other fields are ignored."
+  opts.separator "  query  TYPE QUERY       Queries for items from collection specified by TYPE."
 end
 
-def load(type)
-  puts "Loading items of type #{type}..."
-  items = $stdin.read.split("\n").map { |l| MultiJson.decode(l) }
-  loaded = Soulmate::Loader.new(type).load(items)
-  puts "Loaded a total of #{loaded.size} items"
+def load(type, file)
+  if File.exists?(file)
+    batch_size = ARGV[3].to_i.zero? ? 10000 : ARGV[3].to_i
+    start_time = Time.now.to_i
+
+    puts "Purging existing items of type #{type} ..."
+    loader = Soulmate::Loader.new(type)
+    loader.cleanup
+
+    puts "Loading items of type #{type} in batches of #{batch_size} ..."
+    count = 0
+    begin
+      f = File.open(file)
+      while !f.eof?
+        lines = []
+        batch_size.times do
+          break if f.eof?
+          lines << MultiJson.decode(f.gets)
+          count += 1
+        end
+        loader.load(lines)
+        puts "Loaded #{count} items ..." unless f.eof?
+      end
+    ensure
+      f.close
+    end
+    puts "Loaded a total of #{count} items in #{Time.now.to_i - start_time} second(s)"
+  else
+    puts "Couldn't open file: #{file}"
+  end
 end
 
 def add(type)
@@ -80,7 +105,7 @@ parser.parse!
 
 case ARGV[0]
 when 'load'
-  load ARGV[1]
+  load ARGV[1], ARGV[2]
 when 'add'
   add ARGV[1]
 when 'remove'

--- a/lib/soulmate/loader.rb
+++ b/lib/soulmate/loader.rb
@@ -2,7 +2,7 @@ module Soulmate
 
   class Loader < Base
 
-    def load(items)
+    def cleanup
       # delete the sorted sets for this type
       phrases = Soulmate.redis.smembers(base)
       Soulmate.redis.pipelined do
@@ -19,8 +19,10 @@ module Soulmate
 
       # delete the data stored for this type
       Soulmate.redis.del(database)
+    end
 
-      items.each_with_index do |item, i|
+    def load(items)
+      items.each do |item|
         add(item, :skip_duplicate_check => true)
       end
     end

--- a/lib/soulmate/server.rb
+++ b/lib/soulmate/server.rb
@@ -23,11 +23,12 @@ module Soulmate
       limit = (params[:limit] || 5).to_i
       types = params[:types].map { |t| normalize(t) }
       term  = params[:term]
-      
+      cache = params[:cache] != "false"
+
       results = {}
       types.each do |type|
         matcher = Matcher.new(type)
-        results[type] = matcher.matches_for_term(term, :limit => limit)
+        results[type] = matcher.matches_for_term(term, limit: limit, cache: cache)
       end
       
       MultiJson.encode({

--- a/test/test_soulmate.rb
+++ b/test/test_soulmate.rb
@@ -49,7 +49,7 @@ class TestSoulmate < Test::Unit::TestCase
     matcher = Soulmate::Matcher.new('venues')
     
     # empty the collection
-    loader.load([])
+    loader.cleanup
     results = matcher.matches_for_term("te", :cache => false)
     assert_equal 0, results.size
     
@@ -69,7 +69,7 @@ class TestSoulmate < Test::Unit::TestCase
     matcher = Soulmate::Matcher.new('venues')
     
     # empty the collection
-    loader.load([])
+    loader.cleanup
     
     # initial data
     loader.add("id" => 1, "term" => "Testing this", "score" => 10)


### PR DESCRIPTION
I split the `Soulmate::Loader#load` method into two parts: cleanup and load.
By doing this we can keep calling `Loader#load` without having to blow away the
old data.

I then extended the `bin/soulmate` file to take filename and batch_size
arguments.  By not waiting for all the data to arrive on STDIN, we can tune
the batch_size to reach a consistent memory usage, which also helps speed up
loading as well.

I ran some tests using `time soulmate load sample.json` with various batch_size
parameters.  I inspected memory using `Activity Monitor.app` and took some
averages over 3 runs each.  `sample.json` was a 100,000 line file.

```
batch_size  time  memory_used
   100,000  1:37  219.8
    10,000  1:15  58.2
     1,000  1:13  46
       100  1:14  46.4
```

As you can see, memory stays stable when the batch size is smaller, and loading
data is faster, too.

I haven't touched the other commands in `bin/soulmate`, since I don't have a
need to use them yet.

Tests have been modified to reflect the new `Loader#cleanup` method (they were
using `Loader#load` as a hack anyway), and they all pass.

Fixes #26
