### PR TITLE
Add error message to ArgumentError when adding a new item to a loader and the keys 'id' and 'term' are not defined.

### DIFF
--- a/lib/soulmate/loader.rb
+++ b/lib/soulmate/loader.rb
@@ -28,7 +28,7 @@ module Soulmate
     # "id", "term", "score", "aliases", "data"
     def add(item, opts = {})
       opts = { :skip_duplicate_check => false }.merge(opts)
-      raise ArgumentError, "the keys 'id' and 'term' are not defined for this item" unless item["id"] && item["term"]
+      raise ArgumentError, "Items must specify both an id and a term" unless item["id"] && item["term"]
       
       # kill any old items with this id
       remove("id" => item["id"]) unless opts[:skip_duplicate_check]


### PR DESCRIPTION
I think it is a good practice to add this message when the `ArgumentError` is raised.

I started playing around with this gem and I got an `ArgumentError` when trying to create a simple item in the `Loader`. The only way to realize what was missing was checking part in the documentation and fully in the `add` method in the `Loader` class. I hope this message helps someone else when adding items.
